### PR TITLE
Druid: Updated Druid Version to 0.21.0 and changed the storage mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ This setup takes care of bringing up superset configured to the datasources inge
 5. Edit `./setup/druid/docker-compose.yml` with proper env variables, network settings etc.
 6. Bring up different druid services in different vms if required (especially `historical`) or in a single vm 
    `docker-compose up -d`
-
+---
+**NOTE**
+Check the group ownership of all configuration files, environment files and `storage` folder. Make sure they are not root.
+---
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ This setup takes care of bringing up superset configured to the datasources inge
 5. Edit `./setup/druid/docker-compose.yml` with proper env variables, network settings etc.
 6. Bring up different druid services in different vms if required (especially `historical`) or in a single vm 
    `docker-compose up -d`
----
-**NOTE**
+```
 Check the group ownership of all configuration files, environment files and `storage` folder. Make sure they are not root.
----
+```
 
 
 

--- a/setup/druid/docker-compose.yml
+++ b/setup/druid/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
 
   coordinator:
-    image: apache/druid:0.20.2
+    image: apache/druid:0.21.0
     container_name: coordinator
     volumes:
       - ./storage:/opt/data
@@ -45,7 +45,7 @@ services:
       - analytics-net
 
   broker:
-    image: apache/druid:0.20.2
+    image: apache/druid:0.21.0
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -63,7 +63,7 @@ services:
       - analytics-net
 
   historical:
-    image: apache/druid:0.20.2
+    image: apache/druid:0.21.0
     container_name: historical
     volumes:
       - ./storage:/opt/data
@@ -82,7 +82,7 @@ services:
       - analytics-net
 
   middlemanager:
-    image: apache/druid:0.20.2
+    image: apache/druid:0.21.0
     container_name: middlemanager
     volumes:
       - ./storage:/opt/data
@@ -102,7 +102,7 @@ services:
       - analytics-net
 
   router:
-    image: apache/druid:0.20.2
+    image: apache/druid:0.21.0
     container_name: router
     volumes:
       - router_var:/opt/druid/var

--- a/setup/druid/environment
+++ b/setup/druid/environment
@@ -9,3 +9,6 @@ druid_metadata_storage_type=postgresql
 druid_metadata_storage_connector_connectURI=jdbc:postgresql://postgres:5432/druid
 druid_metadata_storage_connector_user=druid
 druid_metadata_storage_connector_password=somepassword
+
+druid_storage_type=local
+druid_storage_storageDirectory=/opt/data/segments


### PR DESCRIPTION
1. Older druid version gives java.lang.ArithmeticException divide by zero error over datasources, segments and query pages.
2. Without local storage mechanism, Historical is not able to locate segments.