### PR TITLE
Fixed Timezone issue in Superset

### DIFF
--- a/setup/superset/env
+++ b/setup/superset/env
@@ -22,7 +22,7 @@ POSTGRES_PASSWORD=superset
 PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev
 REDIS_HOST=redis
 REDIS_PORT=6379
-
+TZ="Asia/Kolkata"
 FLASK_ENV=development
 SUPERSET_ENV=development
 SUPERSET_LOAD_EXAMPLES=yes


### PR DESCRIPTION
Superset time settings while creating charts were in UTC format. So, TZ property is introduced in environment file to set time zone as per the user